### PR TITLE
Fix undeclared variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,7 @@ var awsmaLite = {
         AWS.config.credentials = new AWS.CognitoIdentityCredentials({
           IdentityPoolId: config.identityPoolId
         })
-        mobileAnalyticsClient = new AMA.Manager(config)
-        return mobileAnalyticsClient
+        return new AMA.Manager(config)
       })
     return mobileAnalyticsManagerPromise
   },


### PR DESCRIPTION
Currently `mobileAnalyticsClient` variable is undeclared and it's an error in strict mode. This PR fixes it.